### PR TITLE
Enroll windows agent during testing

### DIFF
--- a/.github/deploy/.terraform.lock.hcl
+++ b/.github/deploy/.terraform.lock.hcl
@@ -68,6 +68,27 @@ provider "registry.terraform.io/hashicorp/http" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.3.0"
+  constraints = "2.3.0"
+  hashes = [
+    "h1:+l9ZTDGmGdwnuYI5ftUjwP8UgoLw4f4V9xoCzal4LW0=",
+    "h1:U+DbBqKnXSIqC2z7qIko2dy8w6wwuZd89orPvfeqHk0=",
+    "zh:1f1920b3f78c31c6b69cdfe1e016a959667c0e2d01934e1a084b94d5a02cd9d2",
+    "zh:550a3cdae0ddb350942624e7b2e8b31d28bc15c20511553432413b1f38f4b214",
+    "zh:68d1d9ccbfce2ce56b28a23b22833a5369d4c719d6d75d50e101a8a8dbe33b9b",
+    "zh:6ae3ad6d865a906920c313ec2f413d080efe32c230aca711fd106b4cb9022ced",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a0f413d50f54124057ae3dcd9353a797b84e91dc34bcf85c34a06f8aef1f9b12",
+    "zh:a2ac6d4088ceddcd73d88505e18b8226a6e008bff967b9e2d04254ef71b4ac6b",
+    "zh:a851010672e5218bdd4c4ea1822706c9025ef813a03da716d647dd6f8e2cffb0",
+    "zh:aa797561755041ef2fad99ee9ffc12b5e724e246bb019b21d7409afc2ece3232",
+    "zh:c6afa960a20d776f54bb1fc260cd13ead17280ebd87f05b9abcaa841ed29d289",
+    "zh:df0975e86b30bb89717b8c8d6d4690b21db66de06e79e6d6cfda769f3304afe6",
+    "zh:f0d3cc3da72135efdbe8f4cfbfb0f2f7174827887990a5545e6db1981f0d3a7c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.1"
   constraints = "3.2.1"

--- a/.github/deploy/README.md
+++ b/.github/deploy/README.md
@@ -1,0 +1,20 @@
+# Deployment Test
+
+This Terraform module deploys the package policies to an Elastic Cloud instance.
+
+1. Provision Elasticsearch, Kibana, and Fleet Server on Elastic Cloud.
+2. Create an Agent policy.
+3. Install the winlog integration.
+4. Add each winlog package policy to the Agent policy.
+5. Get the fleet enrollment token associated to the Agent policy.
+6. Create an API key to read data from `logs-winlog.*`.
+
+NOTE: This module uses a local-exec hack to workaround the lack of a Fleet
+terraform provider. See https://github.com/elastic/terraform-provider-elasticstack/issues/89.
+
+## Maintenance
+
+The only value that needs updated is the `stack_version` variable. This
+should be updated to test with the latest stack release. And because this
+uses the Elastic Cloud Staging it is possible to test with pre-release
+stack versions.

--- a/.github/deploy/main.tf
+++ b/.github/deploy/main.tf
@@ -19,6 +19,11 @@ terraform {
       source  = "hashicorp/null"
       version = "3.2.1"
     }
+
+    local = {
+      source  = "hashicorp/local"
+      version = "2.3.0"
+    }
   }
 }
 
@@ -28,18 +33,18 @@ provider "ec" {
 }
 
 provider "elasticstack" {
-  kibana {
-    url      = ec_deployment.fleet-demo.kibana[0].https_endpoint
-    username = ec_deployment.fleet-demo.elasticsearch_username
-    password = ec_deployment.fleet-demo.elasticsearch_password
+  elasticsearch {
+    endpoints = [ec_deployment.fleet-winlog.elasticsearch[0].https_endpoint]
+    username  = ec_deployment.fleet-winlog.elasticsearch_username
+    password  = ec_deployment.fleet-winlog.elasticsearch_password
   }
 }
 
-resource "ec_deployment" "fleet-demo" {
-  name = "fleet-winlog-7x-policy-test"
+resource "ec_deployment" "fleet-winlog" {
+  name = "fleet-winlog-7x-policy-${var.env_id}"
 
   region                 = "gcp-us-central1"
-  version                = "8.6.1"
+  version                = var.stack_version
   deployment_template_id = "gcp-general-purpose"
 
   elasticsearch {
@@ -61,19 +66,40 @@ resource "ec_deployment" "fleet-demo" {
 
 // Fetch the fleet server URL from the Fleet API.
 data "http" "fleet-settings" {
-  url = "${ec_deployment.fleet-demo.kibana[0].https_endpoint}/api/fleet/settings"
+  url = "${ec_deployment.fleet-winlog.kibana[0].https_endpoint}/api/fleet/settings"
 
   # Optional request headers
   request_headers = {
     Accept        = "application/json"
-    Authorization = "Basic ${base64encode("${ec_deployment.fleet-demo.elasticsearch_username}:${ec_deployment.fleet-demo.elasticsearch_password}")}"
+    Authorization = "Basic ${base64encode("${ec_deployment.fleet-winlog.elasticsearch_username}:${ec_deployment.fleet-winlog.elasticsearch_password}")}"
   }
 }
 
 locals {
-  basic_auth = format("Basic %s", base64encode(format("%s:%s", ec_deployment.fleet-demo.elasticsearch_username, ec_deployment.fleet-demo.elasticsearch_password)))
+  basic_auth = format("Basic %s", base64encode(format("%s:%s", ec_deployment.fleet-winlog.elasticsearch_username, ec_deployment.fleet-winlog.elasticsearch_password)))
 
-  kibana_url = ec_deployment.fleet-demo.kibana[0].https_endpoint
+  kibana_url = ec_deployment.fleet-winlog.kibana[0].https_endpoint
 
   fleet_server_url = jsondecode(data.http.fleet-settings.response_body).item.fleet_server_hosts[0]
+}
+
+resource "elasticstack_elasticsearch_security_api_key" "count-reader" {
+  name = "count_reader"
+
+  role_descriptors = jsonencode({
+    count_reader = {
+      indices = [
+        {
+          names      = ["logs-winlog.*"],
+          privileges = ["read"]
+        }
+      ]
+    }
+  })
+
+  expiration = "1h"
+
+  metadata = jsonencode({
+    "env" = "testing"
+  })
 }

--- a/.github/deploy/outputs.tf
+++ b/.github/deploy/outputs.tf
@@ -1,5 +1,5 @@
 output "elasticsearch_url" {
-  value = ec_deployment.fleet-demo.elasticsearch[0].https_endpoint
+  value = ec_deployment.fleet-winlog.elasticsearch[0].https_endpoint
 }
 
 output "kibana_url" {
@@ -7,12 +7,12 @@ output "kibana_url" {
 }
 
 output "elasticsearch_username" {
-  value = ec_deployment.fleet-demo.elasticsearch_username
+  value = ec_deployment.fleet-winlog.elasticsearch_username
 }
 
 output "elasticsearch_password" {
   sensitive = true
-  value     = ec_deployment.fleet-demo.elasticsearch_password
+  value     = ec_deployment.fleet-winlog.elasticsearch_password
 }
 
 output "fleet_server_url" {
@@ -24,5 +24,15 @@ output "agent_policy_id" {
 }
 
 output "enrollment_token" {
-  value = local.enrollment_api_key.api_key
+  sensitive = true
+  value     = local.enrollment_api_key.api_key
+}
+
+output "stack_version" {
+  value = var.stack_version
+}
+
+output "count_reader_api_key" {
+  sensitive = true
+  value     = elasticstack_elasticsearch_security_api_key.count-reader.encoded
 }

--- a/.github/deploy/variables.tf
+++ b/.github/deploy/variables.tf
@@ -1,0 +1,9 @@
+variable "stack_version" {
+  description = "Elastic stack version"
+  default     = "8.6.1"
+}
+
+variable "env_id" {
+  description = "Suffix to apply to ESS deployment name."
+  default     = "manual"
+}

--- a/.github/generate/README.md.tftpl
+++ b/.github/generate/README.md.tftpl
@@ -13,6 +13,7 @@ Assumptions:
 - Fleet winlog integration [version][winlog_changelog] is ${fleet_winlog_version}.
 - The "${fleet_namespace}" data stream namespace is used for all data streams.
 - Each Windows event log channel is configured with its own data stream (e.g. logs-winlog.security-${fleet_namespace}).
+- The mappings of the Fleet winlog integration are applied to the data.
 - The listed commands are executed from a directory containing the `policy-*.json`
 files contained in this repository.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  TF_VAR_env_id: ${{github.run_id}}
+
 jobs:
   lint-generate:
     runs-on: ubuntu-latest
@@ -74,6 +77,8 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
 
       - name: Terraform init
         run: terraform init -no-color
@@ -85,17 +90,107 @@ jobs:
         env:
           EC_API_KEY: ${{ secrets.EC_API_KEY }}
 
+      - name: Load Terraform Outputs
+        id: tf_output
+        # NOTE: Masking could be added with this line, but masking prevents
+        # passing the value as an output.
+        # terraform output -json | jq -r 'to_entries | .[].value | select(.sensitive == true) | "::add-mask::" + .value'
+        run: |
+          terraform output -json | jq -r 'to_entries | .[] | .key +"=" + .value.value' >> $GITHUB_OUTPUT
+        working-directory: .github/deploy
+
       - name: Persist terraform state
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: tfstate
           path: .github/deploy/terraform.tfstate*
+          retention-days: 1
+    outputs:
+      elasticsearch_url: ${{ steps.tf_output.outputs.elasticsearch_url }}
+      count_reader_api_key: ${{ steps.tf_output.outputs.count_reader_api_key }}
+      enrollment_token: ${{ steps.tf_output.outputs.enrollment_token }}
+      fleet_server_url: ${{ steps.tf_output.outputs.fleet_server_url }}
+      stack_version: ${{ steps.tf_output.outputs.stack_version }}
 
-  deploy-destroy:
+  # Enroll a Windows Agent.
+  windows-agent:
+    runs-on: windows-latest
+    needs:
+      - deploy
+    steps:
+      - name: Enroll Elastic Agent
+        env:
+          FLEET_SERVER_URL: ${{needs.deploy.outputs.fleet_server_url}}
+          ENROLLMENT_TOKEN: ${{needs.deploy.outputs.enrollment_token}}
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${{needs.deploy.outputs.stack_version}}-windows-x86_64.zip -OutFile elastic-agent.zip
+          Expand-Archive .\elastic-agent.zip -DestinationPath .
+          cd elastic-agent-${{needs.deploy.outputs.stack_version}}-windows-x86_64
+          .\elastic-agent.exe install --non-interactive --url=$env:FLEET_SERVER_URL --enrollment-token=$env:ENROLLMENT_TOKEN
+
+      - name: Sleep while Elastic Agent collects data
+        shell: pwsh
+        run: |
+          Start-Sleep -Seconds 180
+
+  # Query Elasticsearch to verify data was ingested.
+  query-data:
+    runs-on: ubuntu-latest
+    needs:
+      - deploy
+      - windows-agent
+    steps:
+      - name: Verify data streams contain data.
+        env:
+          API_KEY: ${{needs.deploy.outputs.count_reader_api_key}}
+          ES_URL: ${{needs.deploy.outputs.elasticsearch_url}}
+        run: |
+          declare -a data_streams
+          data_streams=(
+          logs-winlog.security-*
+          logs-winlog.windows-powershell-*
+          logs-winlog.powershell-operational-*
+          # Skipping logs-winlog.sysmon-* because it is not installed.
+          )
+
+          tmpfile=$(mktemp -t datastream_count.XXXX)
+
+          echo "### Verification Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Elastic Stack: ${{needs.deploy.outputs.stack_version}}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          for i in "${data_streams[@]}"
+          do
+            if ! curl \
+              --fail-with-body \
+              --header "Authorization: ApiKey $API_KEY" \
+              -o "$tmpfile" \
+              "$ES_URL/${i}/_count";
+            then
+              echo "curl failed checking $i."
+              exit 1
+            fi
+
+            count=$(jq .count "$tmpfile")
+            if [[ "$count" -eq 0 ]]; then
+              echo "$i : No data found." >> $GITHUB_STEP_SUMMARY
+              exit 1
+            else
+              echo "$i : Got <$count> events." >> $GITHUB_STEP_SUMMARY
+            fi
+          done  
+
+  destroy:
     runs-on: ubuntu-latest
     if: ${{ success() || failure() }} # Always run cleanup.
     needs:
       - deploy
+      - windows-agent
+      - query-data
     environment: ess-testing
     steps:
       - name: Checkout
@@ -119,12 +214,3 @@ jobs:
         working-directory: .github/deploy
         env:
           EC_API_KEY: ${{ secrets.EC_API_KEY }}
-
-# TODO: Add a test job that will:
-#   Spin up Elastic Cloud.
-#   Create agent policy.
-#   Add winlog integration packages.
-#   Get enrollment key.
-#   Enroll a Windows Agent.
-#   Verify data is ingested.
-#   Tear down elastic cloud instance.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Assumptions:
 - Fleet winlog integration [version][winlog_changelog] is 1.10.0.
 - The "default" data stream namespace is used for all data streams.
 - Each Windows event log channel is configured with its own data stream (e.g. logs-winlog.security-default).
+- The mappings of the Fleet winlog integration are applied to the data.
 - The listed commands are executed from a directory containing the `policy-*.json`
 files contained in this repository.
 


### PR DESCRIPTION
Enroll an Elastic Agent on a Windows machine. Then verify data
is produced from each winlog package policy (except Sysmon because
Sysmon is not installed on GH runners).