### PR TITLE
Update to winlog 1.12.1

### DIFF
--- a/.github/generate/fleet-winlog.tf
+++ b/.github/generate/fleet-winlog.tf
@@ -44,7 +44,7 @@ variable "winlogbeat_version" {
 variable "fleet_winlog_version" {
   type        = string
   description = "Version of the Fleet winlog integration. See https://docs.elastic.co/en/integrations/winlog#changelog"
-  default     = "1.11.0"
+  default     = "1.12.1"
 }
 
 variable "fleet_namespace" {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ from the respective Winlogbeat module into the Agent policy.
 Assumptions:
 
 - Winlogbeat module scripts are from version v7.17.9.
-- Fleet winlog integration [version][winlog_changelog] is 1.11.0.
+- Fleet winlog integration [version][winlog_changelog] is 1.12.1.
 - The "default" data stream namespace is used for all data streams.
 - Each Windows event log channel is configured with its own data stream (e.g. logs-winlog.security-default).
 - The mappings of the Fleet winlog integration are applied to the data.

--- a/policy-winlog-powershell-operational.json
+++ b/policy-winlog-powershell-operational.json
@@ -25,7 +25,7 @@
   "namespace": "default",
   "package": {
     "name": "winlog",
-    "version": "1.11.0"
+    "version": "1.12.1"
   },
   "policy_id": "$AGENT_POLICY_ID"
 }

--- a/policy-winlog-security.json
+++ b/policy-winlog-security.json
@@ -25,7 +25,7 @@
   "namespace": "default",
   "package": {
     "name": "winlog",
-    "version": "1.11.0"
+    "version": "1.12.1"
   },
   "policy_id": "$AGENT_POLICY_ID"
 }

--- a/policy-winlog-sysmon.json
+++ b/policy-winlog-sysmon.json
@@ -25,7 +25,7 @@
   "namespace": "default",
   "package": {
     "name": "winlog",
-    "version": "1.11.0"
+    "version": "1.12.1"
   },
   "policy_id": "$AGENT_POLICY_ID"
 }

--- a/policy-winlog-windows-powershell.json
+++ b/policy-winlog-windows-powershell.json
@@ -25,7 +25,7 @@
   "namespace": "default",
   "package": {
     "name": "winlog",
-    "version": "1.11.0"
+    "version": "1.12.1"
   },
   "policy_id": "$AGENT_POLICY_ID"
 }


### PR DESCRIPTION
With 1.12.1 the processor to remove the `event.dataset` value is no longer strictly necessary as the field is not a constant_keyword.