### PR TITLE
Bump versions of 7.x and 8.x ES stack

### DIFF
--- a/.github/deploy/variables.tf
+++ b/.github/deploy/variables.tf
@@ -1,6 +1,6 @@
 variable "stack_version" {
   description = "Elastic stack version"
-  default     = "8.10.2"
+  default     = "8.10.4"
 }
 
 variable "env_id" {

--- a/.github/generate/fleet-winlog.tf
+++ b/.github/generate/fleet-winlog.tf
@@ -38,7 +38,7 @@ variable "api_key" {
 variable "winlogbeat_version" {
   type        = string
   description = "Winlogbeat version to obtain the module script processor sources."
-  default     = "v7.17.13"
+  default     = "v7.17.14"
 }
 
 variable "fleet_winlog_version" {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ from the respective Winlogbeat module into the Agent policy.
 
 Assumptions:
 
-- Winlogbeat module scripts are from version v7.17.13.
+- Winlogbeat module scripts are from version v7.17.14.
 - Fleet winlog integration [version][winlog_changelog] is 1.20.0.
 - The "default" data stream namespace is used for all data streams.
 - Each Windows event log channel is configured with its own data stream (e.g. logs-winlog.security-default).


### PR DESCRIPTION
There was no content changes so this effectively just tests against ES and Agent 8.10.4.