### PR TITLE
Change policies to work with new winlog input package v2.0.0

### DIFF
--- a/.github/generate/fleet-winlog.tf
+++ b/.github/generate/fleet-winlog.tf
@@ -44,7 +44,7 @@ variable "winlogbeat_version" {
 variable "fleet_winlog_version" {
   type        = string
   description = "Version of the Fleet winlog integration. See https://docs.elastic.co/en/integrations/winlog#changelog"
-  default     = "1.20.0"
+  default     = "2.0.0"
 }
 
 variable "fleet_namespace" {
@@ -99,7 +99,7 @@ locals {
       winlogs-winlog = {
         enabled = true
         streams = {
-          "winlog.winlog" = {
+          "winlog.winlogs" = {
             enabled = true
             vars = {
               channel                 = policy.channel

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ from the respective Winlogbeat module into the Agent policy.
 Assumptions:
 
 - Winlogbeat module scripts are from version v7.17.14.
-- Fleet winlog integration [version][winlog_changelog] is 1.20.0.
+- Fleet winlog integration [version][winlog_changelog] is 2.0.0.
 - The "default" data stream namespace is used for all data streams.
 - Each Windows event log channel is configured with its own data stream (e.g. logs-winlog.security-default).
 - The mappings of the Fleet winlog integration are applied to the data.

--- a/policy-winlog-powershell-operational.json
+++ b/policy-winlog-powershell-operational.json
@@ -4,7 +4,7 @@
     "winlogs-winlog": {
       "enabled": true,
       "streams": {
-        "winlog.winlog": {
+        "winlog.winlogs": {
           "enabled": true,
           "vars": {
             "channel": "Microsoft-Windows-PowerShell/Operational",
@@ -25,7 +25,7 @@
   "namespace": "default",
   "package": {
     "name": "winlog",
-    "version": "1.20.0"
+    "version": "2.0.0"
   },
   "policy_id": "$AGENT_POLICY_ID"
 }

--- a/policy-winlog-security.json
+++ b/policy-winlog-security.json
@@ -4,7 +4,7 @@
     "winlogs-winlog": {
       "enabled": true,
       "streams": {
-        "winlog.winlog": {
+        "winlog.winlogs": {
           "enabled": true,
           "vars": {
             "channel": "Security",
@@ -25,7 +25,7 @@
   "namespace": "default",
   "package": {
     "name": "winlog",
-    "version": "1.20.0"
+    "version": "2.0.0"
   },
   "policy_id": "$AGENT_POLICY_ID"
 }

--- a/policy-winlog-sysmon.json
+++ b/policy-winlog-sysmon.json
@@ -4,7 +4,7 @@
     "winlogs-winlog": {
       "enabled": true,
       "streams": {
-        "winlog.winlog": {
+        "winlog.winlogs": {
           "enabled": true,
           "vars": {
             "channel": "Sysmon",
@@ -25,7 +25,7 @@
   "namespace": "default",
   "package": {
     "name": "winlog",
-    "version": "1.20.0"
+    "version": "2.0.0"
   },
   "policy_id": "$AGENT_POLICY_ID"
 }

--- a/policy-winlog-windows-powershell.json
+++ b/policy-winlog-windows-powershell.json
@@ -4,7 +4,7 @@
     "winlogs-winlog": {
       "enabled": true,
       "streams": {
-        "winlog.winlog": {
+        "winlog.winlogs": {
           "enabled": true,
           "vars": {
             "channel": "Windows PowerShell",
@@ -25,7 +25,7 @@
   "namespace": "default",
   "package": {
     "name": "winlog",
-    "version": "1.20.0"
+    "version": "2.0.0"
   },
   "policy_id": "$AGENT_POLICY_ID"
 }


### PR DESCRIPTION
Does the required changes to work with the new winlog input package.

<img width="1163" alt="image" src="https://github.com/elastic/fleet-winlog-7x-policies/assets/15213755/e046dac8-6966-4e79-9e1d-6ff3165fae3a">

<img width="1111" alt="image" src="https://github.com/elastic/fleet-winlog-7x-policies/assets/15213755/7f774985-b1af-4e86-ac0e-136aac538857">

<img width="618" alt="image" src="https://github.com/elastic/fleet-winlog-7x-policies/assets/15213755/04d1d149-cea3-44c5-8f5f-489364a4b346">

Depends on https://github.com/elastic/integrations/pull/8010